### PR TITLE
gitignoreにvendorを含める

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 # Ignore bundler config.
 /.bundle
 
-# Ignore vendor
+# Ignore vendor for CodeCommit Build
 /vendor
 
 # Ignore the default SQLite database.


### PR DESCRIPTION
## 概要
- vendorディレクトリを`.gitignore`についかした

## 背景
- sorcery課題でgitの管理対象に`vendor/bundle`が含まれてしまう
- push時にvendor/bundleが含まれてしまっていると自動レビュー時にnokogiri関係のエラーで落ちてしまう

## 該当質問
https://runteq.jp/questions/2684