### PR TITLE
READMEにsasscのインストール手順を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - Ruby 2.6.6 を設定
 - プロジェクトで利用するgemをインストール
-  - `bundle config set --local path 'vendor/bundle'` 
+  - `bundle config --local path 'vendor/bundle'` 
   - `bundle config --local build.sassc -- --disable-march-tune-native`
   - `bundle install`
 - データベース、テーブルを作成


### PR DESCRIPTION
M1Macユーザー用に以下bundle実行時に必要な設定を明記しました。
```sh
bundle config set path 'vendor/bundle'
bundle config build.sassc -- --disable-march-tune-native
bundle install
```

上記そのまま実行すれば問題なく環境構築できることを確認済です。